### PR TITLE
Roll back Error Prone version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ subprojects {
   dependencies {
     // NullAway errorprone plugin
     annotationProcessor 'com.uber.nullaway:nullaway:0.10.7'
-    errorprone 'com.google.errorprone:error_prone_core:2.10.0'
+    errorprone 'com.google.errorprone:error_prone_core:2.23.0'
     // Using github.com/google/error-prone-javac is required when running on
     // JDK 8. Remove when migrating to JDK 11.
     if (System.getProperty('java.version').startsWith('1.8.')) {


### PR DESCRIPTION
This actually enables Error Prone to be executed; no changes to our analysis, as Error Prone still does not catch any bugs.